### PR TITLE
Us 11

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -43,6 +43,8 @@ class ApplicationsController < ApplicationController
 
     if @apps_pets.where("status = ?" , 'approved').count == @apps_pets.count
       @application.update(status: "Approved")
+    elsif @apps_pets.where("status = ? or status = ?",'approved','rejected').count == @apps_pets.count
+      @application.update(status: "Rejected")
     end
   end
 

--- a/spec/features/applications/admin_show_spec.rb
+++ b/spec/features/applications/admin_show_spec.rb
@@ -124,4 +124,27 @@ RSpec.describe 'Applications admin show page', type: :feature do
     expect(page).to have_current_path("/admin/applications/#{@application.id}")
     expect(page).to have_content("Status: Approved")
   end
+
+  it 'updates the app status to rejected if all pets are approved/rejected, with at least one rejection' do
+    expect(page).to have_content("Status: Pending")
+
+    within('.MrPirate') do
+      click_button("Approve")
+    end
+
+    expect(page).to have_content("Status: Pending")
+
+    within(".Clawdia") do
+      click_button("Reject")
+    end
+
+    expect(page).to have_content("Status: Pending")
+
+    within(".LucilleBald") do
+      click_button("Approve")
+    end
+
+    expect(page).to have_current_path("/admin/applications/#{@application.id}")
+    expect(page).to have_content("Status: Rejected")
+  end
 end


### PR DESCRIPTION
- Add test for application rejected status
- Add functionality to reject application when all pets approved/rejected and 1+ rejection exists